### PR TITLE
Prevent running in production

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,9 @@
 #![allow(unused_mut)]
 #![allow(unused_unsafe)]
 
+#[cfg(not(debug_assertions))]
+compile_error!("Don't deploy this shit to production you madman");
+
 /// Changes value of immutable variable.
 /// 
 /// Example:


### PR DESCRIPTION
I was going to fix this crate to make it not UB (especially it’s worth noting that `change` and `get_mut` [are unconditionally UB no matter how they’re called](https://doc.rust-lang.org/nomicon/transmutes.html#:~:text=Transmuting%20an,special.)) but I realize that it’s likely not the point. So you get this instead, making sure at least nobody attempts to actually use it. The error message was stolen from `fake-static`.